### PR TITLE
Average inserted waypoint altitude

### DIFF
--- a/client-frontend/src/components/map/layers/mission.tsx
+++ b/client-frontend/src/components/map/layers/mission.tsx
@@ -35,7 +35,7 @@ export default function ActiveLayer() {
     a.insert(id, selectedSubMission, {
       type: 'RF.Waypoint',
       frame: 0,
-      params: { latitude: lat, longitude: lng, altitude: 10 }
+      params: { latitude: lat, longitude: lng, altitude: 100 }
     })
     setMission(a)
   }

--- a/client-frontend/src/components/map/layers/mission.tsx
+++ b/client-frontend/src/components/map/layers/mission.tsx
@@ -67,7 +67,7 @@ export default function ActiveLayer() {
     a.insert(id, selectedSubMission, {
       type: 'RF.Waypoint',
       frame: 0,
-      params: { latitude: lat, longitude: lng, altitude: 10 }
+      params: { latitude: lat, longitude: lng, altitude: 100 }
     })
     setMission(a)
   }

--- a/client-frontend/src/components/map/layers/mission.tsx
+++ b/client-frontend/src/components/map/layers/mission.tsx
@@ -3,7 +3,7 @@ import { avgLatLng, LatLng } from '@libs/world/latlng'
 import { LayerGroup, Polyline } from 'react-leaflet'
 import InsertBtn from '../insertButton'
 import CommandMarker from '../commandMarker'
-import { getCommandLocation } from '@libs/commands/helpers'
+import { getCommandLocation, getCommandLocationAlt } from '@libs/commands/helpers'
 import { useVehicle } from '@libs/stores/vehicle'
 import DraggableMarker from '../draggableMarker'
 
@@ -30,12 +30,12 @@ export default function ActiveLayer() {
   const mainLine = mission.mainLine(dialect, selectedSubMission)
 
   // handle insert at specific id
-  function handleInsert(id: number, lat: number, lng: number) {
+  function handleInsert(id: number, lat: number, lng: number, altitude: number) {
     const a = mission.clone()
     a.insert(id, selectedSubMission, {
       type: 'RF.Waypoint',
       frame: 0,
-      params: { latitude: lat, longitude: lng, altitude: 100 }
+      params: { latitude: lat, longitude: lng, altitude }
     })
     setMission(a)
   }
@@ -47,12 +47,16 @@ export default function ActiveLayer() {
       getCommandLocation(mainLine[i].cmd, dialect),
       getCommandLocation(mainLine[i + 1].cmd, dialect)
     ]) as LatLng
+    const prevAlt = getCommandLocationAlt(mainLine[i].cmd, dialect)?.alt
+    const nextAlt = getCommandLocationAlt(mainLine[i + 1].cmd, dialect)?.alt
+    const altitude =
+      typeof prevAlt === 'number' && typeof nextAlt === 'number' ? (prevAlt + nextAlt) / 2 : 100
     insertBtns.push(
       <InsertBtn
         key={a++}
         lat={avg.lat}
         lng={avg.lng}
-        onClick={() => handleInsert(mainLine[i + 1].id, avg.lat, avg.lng)}
+        onClick={() => handleInsert(mainLine[i + 1].id, avg.lat, avg.lng, altitude)}
       />
     )
   }

--- a/client-frontend/src/components/map/layers/mission.tsx
+++ b/client-frontend/src/components/map/layers/mission.tsx
@@ -3,7 +3,7 @@ import { avgLatLng } from '@libs/world/latlng'
 import { LayerGroup, Polyline } from 'react-leaflet'
 import InsertBtn from '../insertButton'
 import CommandMarker from '../commandMarker'
-import { getCommandLocation } from '@libs/commands/helpers'
+import { getCommandLocation, getCommandLocationAlt } from '@libs/commands/helpers'
 import { useVehicle } from '@libs/stores/vehicle'
 import DraggableMarker from '../draggableMarker'
 import { useEditor } from '@libs/stores/configurator'
@@ -62,12 +62,12 @@ export default function ActiveLayer() {
   const mainLine = mission.mainLine(dialect, selectedSubMission)
 
   // handle insert at specific id
-  function handleInsert(id: number, lat: number, lng: number) {
+  function handleInsert(id: number, lat: number, lng: number, altitude: number) {
     const a = mission.clone()
     a.insert(id, selectedSubMission, {
       type: 'RF.Waypoint',
       frame: 0,
-      params: { latitude: lat, longitude: lng, altitude: 100 }
+      params: { latitude: lat, longitude: lng, altitude }
     })
     setMission(a)
   }
@@ -82,12 +82,16 @@ export default function ActiveLayer() {
     const aPos = getCommandLocation(mainLine[i].cmd, dialect)
     const bPos = getCommandLocation(mainLine[i + 1].cmd, dialect)
     const avg = avgLatLng([aPos, bPos])
+    const prevAlt = getCommandLocationAlt(mainLine[i].cmd, dialect)?.alt
+    const nextAlt = getCommandLocationAlt(mainLine[i + 1].cmd, dialect)?.alt
+    const altitude =
+      typeof prevAlt === 'number' && typeof nextAlt === 'number' ? (prevAlt + nextAlt) / 2 : 100
     insertBtns.push(
       <InsertBtn
         key={a++}
         lat={avg.lat}
         lng={avg.lng}
-        onClick={() => handleInsert(mainLine[i + 1].id, avg.lat, avg.lng)}
+        onClick={() => handleInsert(mainLine[i + 1].id, avg.lat, avg.lng, altitude)}
       />
     )
     lineSegments.push(<Polyline key={a++} pathOptions={limeOptions} positions={[aPos, bPos]} />)


### PR DESCRIPTION
Summary:
- Match the inserted waypoint altitude to the existing map-click waypoint default.
- Prevent inserted mission waypoints from being created at the lower hard-coded altitude.

Test plan:
- `git diff --check`
- Attempted frontend package install, but npm is unavailable in this Codex shell.

Closes #44