### PR TITLE
Fix re-renders

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -33,5 +33,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-args: >
             ${{ github.event_name == 'push' && '--prod' || '' }}
+            --build-env APP_VERSION=${{ env.APP_VERSION }}
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -21,6 +21,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Generate version
+        run: echo "APP_VERSION=$(git describe --tags --dirty)" >> $GITHUB_ENV
+
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v42.2.0
         with:

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v42.2.0

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "readyflight",
@@ -69,11 +70,12 @@
       },
     },
     "docs": {
-      "name": "@readyflight/docs",
+      "name": "@readyflight/docs-website",
+      "version": "0.0.1",
     },
     "electron": {
       "name": "@readyflight/electron",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/tsconfig": "^2.0.0",
@@ -375,7 +377,7 @@
 
     "@readyflight/client-frontend": ["@readyflight/client-frontend@workspace:client-frontend"],
 
-    "@readyflight/docs": ["@readyflight/docs@workspace:docs"],
+    "@readyflight/docs-website": ["@readyflight/docs-website@workspace:docs"],
 
     "@readyflight/electron": ["@readyflight/electron@workspace:electron"],
 

--- a/client-frontend/package.json
+++ b/client-frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "GIT_VERSION=$(git describe --tags --dirty) vite",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host",
     "lint": "eslint --cache .",

--- a/client-frontend/vite.config.mts
+++ b/client-frontend/vite.config.mts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { execSync } from 'child_process'
 
-const gitVersion = execSync('git describe --tags --dirty').toString().trim()
+const gitVersion = JSON.stringify(process.env.APP_VERSION) || execSync('git describe --tags --dirty')
 
 // Web-only Vite config; Electron uses electron.vite.config.ts
 export default defineConfig({

--- a/electron/electron.vite.config.ts
+++ b/electron/electron.vite.config.ts
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import { execSync } from 'child_process'
 
-const gitVersion = execSync('git describe --tags --dirty')
+const gitVersion = JSON.stringify(process.env.APP_VERSION) || execSync('git describe --tags --dirty')
   .toString()
   .trim()
 

--- a/libs/src/mission/ardupilot/ardupilot.ts
+++ b/libs/src/mission/ardupilot/ardupilot.ts
@@ -94,7 +94,9 @@ function flushPatch() {
   }
   requestAnimationFrame(flushPatch)
 }
-requestAnimationFrame(flushPatch)
+if (typeof requestAnimationFrame !== "undefined") {
+  requestAnimationFrame(flushPatch)
+}
 
 function processFrame(
   data: ArrayBuffer,

--- a/libs/src/mission/ardupilot/ardupilot.ts
+++ b/libs/src/mission/ardupilot/ardupilot.ts
@@ -82,7 +82,8 @@ function buildMissionItemInt(item: MavCommand, seq: number): MissionItemInt {
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 let heartbeatTimeout: ReturnType<typeof setInterval> | null = null
 
-// we need to batch updates
+// The telemetry messages come in to quickly to use setState every message
+// We will group the state updates here and "flush" the update to state
 let pendingPatch: Partial<VehicleState> = {}
 
 // apply patches the useVehicle state on animation request frame ~60fps
@@ -97,7 +98,6 @@ requestAnimationFrame(flushPatch)
 
 function processFrame(
   data: ArrayBuffer,
-  setVehicleState: (state: Partial<import("@libs/vehicle/state").VehicleState>) => void,
   sendPacket: (buf: ArrayBuffer) => void
 ): void {
   const msg = decodePacket(data)

--- a/libs/src/mission/ardupilot/ardupilot.ts
+++ b/libs/src/mission/ardupilot/ardupilot.ts
@@ -33,6 +33,7 @@ import { Heartbeat } from "./mavlink-assets/messages/heartbeat"
 import { useVehicle } from "@libs/stores/vehicle"
 import { RequestDataStream } from "./mavlink-assets/messages/request-data-stream"
 import { MavLinkStreamParser } from "./mavlink-stream-parser"
+import { VehicleState } from "@libs/vehicle/state"
 
 // ---------------------------------------------------------------------------
 // Mission upload state — one active upload at a time.
@@ -81,6 +82,19 @@ function buildMissionItemInt(item: MavCommand, seq: number): MissionItemInt {
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null
 let heartbeatTimeout: ReturnType<typeof setInterval> | null = null
 
+// we need to batch updates
+let pendingPatch: Partial<VehicleState> = {}
+
+// apply patches the useVehicle state on animation request frame ~60fps
+function flushPatch() {
+  if (Object.keys(pendingPatch).length > 0) {
+    useVehicle.setState(pendingPatch)
+    pendingPatch = {}
+  }
+  requestAnimationFrame(flushPatch)
+}
+requestAnimationFrame(flushPatch)
+
 function processFrame(
   data: ArrayBuffer,
   setVehicleState: (state: Partial<import("@libs/vehicle/state").VehicleState>) => void,
@@ -95,14 +109,14 @@ function processFrame(
     }
     heartbeatTimeout = setTimeout(() => {
       console.log("No heartbeat, disconecting");
-      useVehicle.setState({ connected: false })
+      Object.assign(pendingPatch, { connected: false })
       clearTimeout(heartbeatTimer)
     }, 3000);
     const connected = useVehicle.getState().connected
 
     const isArmed = (msg.base_mode & MavModeFlag.MAV_MODE_FLAG_SAFETY_ARMED) !== 0;
 
-    setVehicleState({
+    Object.assign(pendingPatch, {
       mode: msg.custom_mode,
       isArmed: isArmed
     })
@@ -132,7 +146,7 @@ function processFrame(
       useVehicle.setState({ connected: true })
     }
   } else if (msg instanceof GlobalPositionInt) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       alt: msg.alt / 1000,
       heading: msg.hdg / 100,
       lat: msg.lat / 10000000,
@@ -140,7 +154,7 @@ function processFrame(
       relativeAlt: msg.relative_alt / 100
     })
   } else if (msg instanceof Attitude) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       roll: rad2deg(msg.roll),
       pitch: rad2deg(msg.pitch),
       yaw: rad2deg(msg.yaw),
@@ -149,39 +163,39 @@ function processFrame(
       yawRate: msg.yawspeed
     })
   } else if (msg instanceof GpsRawInt) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       gpsSatellites: msg.satellites_visible,
       gpsFixType: msg.fix_type,
       groundspeed: msg.vel !== 65535 ? msg.vel / 100 : null,
       hdop: msg.eph
     })
   } else if (msg instanceof BatteryStatus) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       batteryVoltage: msg.voltages / 1000,
       batteryCurrent: msg.current_battery,
       batteryRemaining: msg.time_remaining,
       batteryConsumedmAh: msg.current_consumed,
     })
   } else if (msg instanceof VfrHud) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       airspeed: msg.airspeed,
       climb: msg.climb,
       groundspeed: msg.groundspeed,
       throttle: msg.throttle
     })
   } else if (msg instanceof Wind) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       windDirection: msg.direction,
       windHSpeed: msg.speed,
       windZSpeed: msg.speed_z
     })
   } else if (msg instanceof AoaSsa) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       AOA: msg.AOA,
       SSA: msg.SSA
     })
   } else if (msg instanceof MissionCurrent) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       missionId: msg.mission_id,
       missionSeq: msg.seq,
       missionMode: msg.mission_mode,
@@ -189,7 +203,7 @@ function processFrame(
       missionTotal: msg.total
     })
   } else if (msg instanceof NavControllerOutput) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       altError: msg.alt_error,
       aspdError: msg.aspd_error,
       navBearing: msg.nav_bearing,
@@ -200,7 +214,7 @@ function processFrame(
       xtrackError: msg.xtrack_error
     })
   } else if (msg instanceof EkfStatusReport) {
-    setVehicleState({
+    Object.assign(pendingPatch, {
       airspeedVariance: msg.airspeed_variance,
       compassVariance: msg.compass_variance,
       posHorizVariance: msg.pos_horiz_variance,
@@ -246,7 +260,6 @@ function processFrame(
     }
     resetUploadState()
   } else {
-    console.log(msg);
   }
 }
 


### PR DESCRIPTION
Reduce the amount of re-renders that are triggered, previously caused thousands of tasks to be spawned and would cause a backlog and delay in telemetry.

Fixed by creating a pendingPatch which telemetry messages modify first. then the pendingPatch is applyed to state on animation request frame, ~60fps